### PR TITLE
Fix blank widget when image loads quickly

### DIFF
--- a/lib/panorama_viewer.dart
+++ b/lib/panorama_viewer.dart
@@ -333,7 +333,7 @@ class PanoramaState extends State<PanoramaViewer>
     surface?.mesh.textureRect = Rect.fromLTWH(0, 0,
         imageInfo.image.width.toDouble(), imageInfo.image.height.toDouble());
     scene!.texture = imageInfo.image;
-    scene!.update();
+    scene!.updateTexture();
     widget.onImageLoad?.call();
   }
 


### PR DESCRIPTION
When changing a scene's mesh textures, `updateTexture()` should be called to ensure that the texture is rendered properly. 

I've been able to reliably replicate a bug where the image doesn't show on screen. [This ticket](https://github.com/dariocavada/panorama_viewer/issues/3) also mentions the problem. This only appears to happen for images that load synchronously.

I believe this is caused by a race condition when the image provider completes synchronously.

When the image loads asynchronously this is the order of operations:
1. `scene._updateTexture` is called and gets all of the meshes in the world (the world is currently empty)
2. `scene._updateTexture` gets to the async await and pauses execution
3. `panoramaViewer._onSceneCreated` is called and adds the image provider listener
4. `scene._updateTexture` resumes and sets `texture` to null
5. `panoramaViewer._updateTexture` is called and sets the photo texture

When the image loads synchronously, this is the order of operations:
1. `scene._updateTexture` is called and gets all of the meshes in the world (the world is currently empty)
2. `scene._updateTexture` gets to the async await and pauses execution
3. `panoramaViewer._onSceneCreated` is called and adds the image provider listener
4. `panoramaViewer._updateTexture` is called and sets the photo texture
5. `scene._updateTexture` resumes and sets `texture` to null

This fix triggers the `scene._updateTexture` again, once the world has been populated with the image mesh.